### PR TITLE
テキストボックス内の青い枠を無くす

### DIFF
--- a/frontend/src/components/DraggableTextBox.module.css
+++ b/frontend/src/components/DraggableTextBox.module.css
@@ -7,6 +7,10 @@
   z-index: 1;
 }
 
+.editorContent > * > div {
+  outline: none;
+}
+
 .textBox:hover div {
   display: block;
 }

--- a/frontend/src/components/DraggableTextBox.tsx
+++ b/frontend/src/components/DraggableTextBox.tsx
@@ -214,6 +214,7 @@ const DraggableTextBox: React.FC<Props> = ({ textbox }) => {
     <div
       style={style}
       onMouseDown={handleDragMouseDown}
+      onDoubleClick={() => textbox.editor.commands.focus()}
       className={styles.textBox}
     >
       <div

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -2,8 +2,18 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    Fira Sans,
+    Droid Sans,
+    Helvetica Neue,
+    sans-serif;
 }
 
 a {


### PR DESCRIPTION
## Issue 
close #44  

## 概要

### 実装内容
- テキストボックス内のtiptapエディタの枠線を無効化
- テキストボックス内をダブルクリックするとエディタにフォーカス
  - Googleスライドの挙動に準拠
  
### スクリーンショット

https://github.com/AllenShintani/Skalp_AI/assets/36080294/fc324678-2214-427a-be69-c15881f161e6

