### PR TITLE
httpOnlyをtrueにしてサーバーサイドで認証実装

### DIFF
--- a/backend/src/routers/login.ts
+++ b/backend/src/routers/login.ts
@@ -78,7 +78,7 @@ export const loginRouter = t.router({
         }
         const token = ctx.fastify.jwt.sign({ userId: prismaUser.id });
         ctx.reply.setCookie("token", token, {
-          httpOnly: false,
+          httpOnly: true,
           secure: process.env.NODE_ENV === "production",
           sameSite: "strict",
           path: "/",

--- a/backend/src/routers/signup.ts
+++ b/backend/src/routers/signup.ts
@@ -69,7 +69,7 @@ export const signupRouter = t.router({
 
         const token = ctx.fastify.jwt.sign({ userId: prismaUser.id });
         ctx.reply.setCookie("token", token, {
-          httpOnly: false,
+          httpOnly: true,
           secure: process.env.NODE_ENV === "production",
           sameSite: "strict",
           path: "/",

--- a/frontend/src/hooks/useAuthCheck.ts
+++ b/frontend/src/hooks/useAuthCheck.ts
@@ -1,0 +1,53 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+const useAuthCheck = () => {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const checkAuth = async () => {
+      const publicRoutes = ['/signup', '/login']
+      const isPublicRoute = publicRoutes.includes(router.pathname)
+
+      try {
+        const response = await fetch('/api/checkAuth', {
+          method: 'GET',
+          credentials: 'include',
+        })
+
+        const data = await response.json()
+        const isAuthenticated = response.ok && data.isAuthenticated
+
+        if (isMounted) {
+          if (!isAuthenticated && !isPublicRoute) {
+            await router.push('/login')
+          } else if (isAuthenticated && isPublicRoute) {
+            await router.push('/workspace')
+          }
+        }
+      } catch (error) {
+        console.error('Error checking authentication', error)
+        if (isMounted && !isPublicRoute) {
+          await router.push('/login')
+        }
+      }
+
+      if (isMounted) {
+        setLoading(false)
+      }
+    }
+
+    checkAuth()
+
+    return () => {
+      isMounted = false
+    }
+  }, [router])
+
+  return { loading }
+}
+
+export default useAuthCheck

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,43 +1,9 @@
 import '../styles/globals.css'
-import { getCookie, deleteCookie } from 'cookies-next'
 import type { AppProps } from 'next/app'
-import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import useAuthCheck from '../hooks/useAuthCheck'
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const router = useRouter()
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    const token = getCookie('token')
-
-    const handleRouteChange = async () => {
-      if (!token) {
-        if (router.pathname !== '/signup' && router.pathname !== '/login') {
-          await router.push('/login')
-        }
-        setLoading(false)
-        return
-      }
-
-      if (token) {
-        try {
-          // トークンをデコードして有効かどうかを確認
-          JSON.parse(atob(token.split('.')[1]))
-          if (router.pathname === '/login' || router.pathname === '/signup') {
-            await router.push(`/workspace`)
-          }
-        } catch (error) {
-          // 無効なトークンの場合はクッキーを削除し、loginページへリダイレクト
-          deleteCookie('token')
-          await router.push('/login')
-        }
-      }
-      setLoading(false)
-    }
-
-    handleRouteChange()
-  }, [router])
+  const { loading } = useAuthCheck()
 
   if (loading) {
     return <div>Loading...</div>

--- a/frontend/src/pages/api/checkAuth.ts
+++ b/frontend/src/pages/api/checkAuth.ts
@@ -1,0 +1,23 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { verify } from 'jsonwebtoken'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+const checkAuth = (req: NextApiRequest, res: NextApiResponse) => {
+  const token = req.cookies.token
+  const secret = process.env.JWT_SECRET
+
+  if (!token || !secret) {
+    return res.status(401).json({ isAuthenticated: false })
+  }
+
+  try {
+    verify(token, secret)
+    return res.status(200).json({ isAuthenticated: true })
+  } catch (error) {
+    return res.status(401).json({ isAuthenticated: false })
+  }
+}
+
+export default checkAuth

--- a/frontend/src/pages/api/checkAuth.ts
+++ b/frontend/src/pages/api/checkAuth.ts
@@ -1,4 +1,4 @@
-import { NextApiRequest, NextApiResponse } from 'next'
+import type { NextApiRequest, NextApiResponse } from 'next'
 import { verify } from 'jsonwebtoken'
 import dotenv from 'dotenv'
 


### PR DESCRIPTION
## https://github.com/AllenShintani/Skalp_AI/issues/67

- #XX

## 概要

- サーバーサイドで認証を完結することでhttpOnlyの属性をtrueにした

## 実装した内容の詳細

- フロントエンドでcookieにJSで操作できなくすることでXRRのリスクを抑えることができる。

## その他

- ページに遷移した際にCookieに入っているtokenが正しいか確認しているためログインしようとした時に初めに(tokenがまだ存在しない時)ブラウザコンソールに401エラーが出る
