### PR TITLE
Fix/#73

### DIFF
--- a/frontend/src/components/DraggableSlideImage.module.css
+++ b/frontend/src/components/DraggableSlideImage.module.css
@@ -1,5 +1,6 @@
 .SlideImage {
   border: 1px solid #d1d1d1;
+  z-index: -1;
 }
 
 .verticalLine {

--- a/frontend/src/components/DraggableSlideImage.tsx
+++ b/frontend/src/components/DraggableSlideImage.tsx
@@ -9,6 +9,7 @@ import type { ResizeDivs } from '@/types/DraggableTextBox'
 
 type Props = {
   image: SlideImage
+  scale: number
 }
 
 const handleResizeDivs: ResizeDivs[] = [
@@ -22,7 +23,7 @@ const handleResizeDivs: ResizeDivs[] = [
   { direction: 'northWest', className: resizeStyles.resizeHandleNorthWest },
 ]
 
-const DraggableSlideImage: React.FC<Props> = ({ image }) => {
+const DraggableSlideImage: React.FC<Props> = ({ image, scale }) => {
   const {
     isDragging,
     isVerticalCenter,
@@ -30,10 +31,15 @@ const DraggableSlideImage: React.FC<Props> = ({ image }) => {
     handleDragMouseDown,
     handleDragMouseUp,
     handleDragMouseMove,
-  } = useDrag({ x: image.x, y: image.y }, image.id, {
-    width: image.width,
-    height: image.height,
-  })
+  } = useDrag(
+    { x: image.x, y: image.y },
+    image.id,
+    {
+      width: image.width,
+      height: image.height,
+    },
+    scale,
+  )
 
   const {
     isResizing,
@@ -44,6 +50,7 @@ const DraggableSlideImage: React.FC<Props> = ({ image }) => {
     { width: image.width, height: image.height },
     { x: image.x, y: image.y },
     image.id,
+    scale,
   )
 
   const handleMouseMove = useCallback(

--- a/frontend/src/components/DraggableSlideImage.tsx
+++ b/frontend/src/components/DraggableSlideImage.tsx
@@ -3,14 +3,13 @@ import styles from './DraggableSlideImage.module.css'
 import { useCallback, useEffect } from 'react'
 import type { SlideImage } from '@/types/Slide'
 import resizeStyles from './ResizeHandles.module.css'
+import { useDrag } from '@/hooks/useDrag'
+import { useResize } from '@/hooks/useResize'
+import type { ResizeDivs } from '@/types/DraggableTextBox'
 
 type Props = {
   image: SlideImage
 }
-
-import { useDrag } from '@/hooks/useDrag'
-import { useResize } from '@/hooks/useResize'
-import type { ResizeDivs } from '@/types/DraggableTextBox'
 
 const handleResizeDivs: ResizeDivs[] = [
   { direction: 'north', className: resizeStyles.resizeHandleNorth },
@@ -26,17 +25,18 @@ const handleResizeDivs: ResizeDivs[] = [
 const DraggableSlideImage: React.FC<Props> = ({ image }) => {
   const {
     isDragging,
-    position,
     isVerticalCenter,
     isHorizontalCenter,
     handleDragMouseDown,
     handleDragMouseUp,
     handleDragMouseMove,
-  } = useDrag({ x: image.x, y: image.y }, image.id)
+  } = useDrag({ x: image.x, y: image.y }, image.id, {
+    width: image.width,
+    height: image.height,
+  })
 
   const {
     isResizing,
-    size,
     handleResizeMouseDown,
     handleResizeMouseMove,
     handleResizeMouseUp,
@@ -46,16 +46,6 @@ const DraggableSlideImage: React.FC<Props> = ({ image }) => {
     image.id,
   )
 
-  const style: React.CSSProperties = {
-    transform: `translate3d(${position.x}px, ${position.y}px, 0)`,
-    position: 'absolute',
-    width: `${size.width}px`,
-    height: `${size.height}px`,
-    boxSizing: 'border-box',
-    outline: image.isSelected ? 'solid 1px blue' : 'none',
-    userSelect: 'none', // Prevent text selection(入力の無効化はtiptapにメソッドが存在する為、注意が必要)
-  }
-
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
       handleDragMouseMove(e)
@@ -63,6 +53,7 @@ const DraggableSlideImage: React.FC<Props> = ({ image }) => {
     },
     [handleDragMouseMove, handleResizeMouseMove],
   )
+
   const handleMouseUp = useCallback(() => {
     handleDragMouseUp()
     handleResizeMouseUp()
@@ -75,14 +66,17 @@ const DraggableSlideImage: React.FC<Props> = ({ image }) => {
       document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', handleMouseUp)
     }
-  }, [
-    handleDragMouseMove,
-    handleDragMouseUp,
-    handleMouseMove,
-    handleMouseUp,
-    handleResizeMouseMove,
-    handleResizeMouseUp,
-  ])
+  }, [handleMouseMove, handleMouseUp])
+
+  const style: React.CSSProperties = {
+    transform: `translate3d(${image.x}px, ${image.y}px, 0)`,
+    position: 'absolute',
+    width: `${image.width}px`,
+    height: `${image.height}px`,
+    boxSizing: 'border-box',
+    outline: image.isSelected ? 'solid 1px blue' : 'none',
+    userSelect: 'none', // Prevent text selection
+  }
 
   return (
     <div
@@ -101,8 +95,8 @@ const DraggableSlideImage: React.FC<Props> = ({ image }) => {
         alt="image"
         onMouseDown={handleDragMouseDown}
         onDragStart={(e) => e.preventDefault()}
-        width={size.width}
-        height={size.height}
+        width={image.width}
+        height={image.height}
       />
       <div
         className={styles.resizeHandles}

--- a/frontend/src/components/DraggableTextBox.module.css
+++ b/frontend/src/components/DraggableTextBox.module.css
@@ -1,5 +1,6 @@
 .textBox {
   border: 1px solid #d1d1d1;
+  z-index: 0;
 }
 
 .verticalLine {
@@ -9,6 +10,7 @@
   width: 1px;
   height: 3000px;
   background-color: #e71515;
+  z-index: 3;
 }
 
 .horizontalLine {
@@ -18,6 +20,7 @@
   width: 3000px;
   height: 1px;
   background-color: #e71515;
+  z-index: 3;
 }
 
 .editorContent {

--- a/frontend/src/components/DraggableTextBox.tsx
+++ b/frontend/src/components/DraggableTextBox.tsx
@@ -7,11 +7,10 @@ import { useDrag } from '@/hooks/useDrag'
 import { useResize } from '@/hooks/useResize'
 import type { TextBox } from '@/types/Slide'
 import type { ResizeDivs } from '@/types/DraggableTextBox'
-import { slidesState } from '@/jotai/atoms'
-import { useAtom } from 'jotai'
 
 type Props = {
   textbox: TextBox
+  scale: number
 }
 
 const handleResizeDivs: ResizeDivs[] = [
@@ -25,9 +24,7 @@ const handleResizeDivs: ResizeDivs[] = [
   { direction: 'northWest', className: resizeStyles.resizeHandleNorthWest },
 ]
 
-const DraggableTextBox: React.FC<Props> = ({ textbox }) => {
-  const [slides, setSlides] = useAtom(slidesState)
-
+const DraggableTextBox: React.FC<Props> = ({ textbox, scale }) => {
   const {
     isResizing,
     handleResizeMouseDown,
@@ -37,6 +34,7 @@ const DraggableTextBox: React.FC<Props> = ({ textbox }) => {
     { width: textbox.width, height: textbox.height },
     { x: textbox.x, y: textbox.y },
     textbox.id,
+    scale,
   )
 
   const {
@@ -46,15 +44,21 @@ const DraggableTextBox: React.FC<Props> = ({ textbox }) => {
     handleDragMouseDown,
     handleDragMouseUp,
     handleDragMouseMove,
-  } = useDrag({ x: textbox.x, y: textbox.y }, textbox.id, {
-    width: textbox.width,
-    height: textbox.height,
-  })
+  } = useDrag(
+    { x: textbox.x, y: textbox.y },
+    textbox.id,
+    {
+      width: textbox.width,
+      height: textbox.height,
+    },
+    scale,
+  )
 
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
       handleDragMouseMove(e)
       handleResizeMouseMove(e)
+      // console.log(scale)
     },
     [handleDragMouseMove, handleResizeMouseMove],
   )

--- a/frontend/src/components/DraggableTextBox.tsx
+++ b/frontend/src/components/DraggableTextBox.tsx
@@ -7,6 +7,8 @@ import { useDrag } from '@/hooks/useDrag'
 import { useResize } from '@/hooks/useResize'
 import type { TextBox } from '@/types/Slide'
 import type { ResizeDivs } from '@/types/DraggableTextBox'
+import { slidesState } from '@/jotai/atoms'
+import { useAtom } from 'jotai'
 
 type Props = {
   textbox: TextBox
@@ -24,19 +26,10 @@ const handleResizeDivs: ResizeDivs[] = [
 ]
 
 const DraggableTextBox: React.FC<Props> = ({ textbox }) => {
-  const {
-    isDragging,
-    position,
-    isVerticalCenter,
-    isHorizontalCenter,
-    handleDragMouseDown,
-    handleDragMouseUp,
-    handleDragMouseMove,
-  } = useDrag({ x: textbox.x, y: textbox.y }, textbox.id)
+  const [slides, setSlides] = useAtom(slidesState)
 
   const {
     isResizing,
-    size,
     handleResizeMouseDown,
     handleResizeMouseMove,
     handleResizeMouseUp,
@@ -45,6 +38,18 @@ const DraggableTextBox: React.FC<Props> = ({ textbox }) => {
     { x: textbox.x, y: textbox.y },
     textbox.id,
   )
+
+  const {
+    isDragging,
+    isVerticalCenter,
+    isHorizontalCenter,
+    handleDragMouseDown,
+    handleDragMouseUp,
+    handleDragMouseMove,
+  } = useDrag({ x: textbox.x, y: textbox.y }, textbox.id, {
+    width: textbox.width,
+    height: textbox.height,
+  })
 
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
@@ -69,10 +74,10 @@ const DraggableTextBox: React.FC<Props> = ({ textbox }) => {
   }, [handleMouseMove, handleMouseUp])
 
   const style: React.CSSProperties = {
-    transform: `translate3d(${position.x}px, ${position.y}px, 0)`,
+    transform: `translate3d(${textbox.x}px, ${textbox.y}px, 0)`,
     position: 'absolute',
-    width: `${size.width}px`,
-    height: `${size.height}px`,
+    width: `${textbox.width}px`,
+    height: `${textbox.height}px`,
     boxSizing: 'border-box',
     outline: textbox.isSelected ? 'solid 1px blue' : 'none',
     userSelect: 'none', // Prevent text selection(入力の無効化はtiptapにメソッドが存在する為、注意が必要)

--- a/frontend/src/components/SlideEditor.tsx
+++ b/frontend/src/components/SlideEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { DndContext } from '@dnd-kit/core'
 import StarterKit from '@tiptap/starter-kit'
 import { Editor } from '@tiptap/react'
@@ -27,6 +27,7 @@ import { useRouter } from 'next/router'
 const SlideEditor = () => {
   const [slides, setSlides] = useAtom(slidesState)
   const [currentSlide, setCurrentSlide] = useAtom(currentSlideIdState)
+  const [scale, setScale] = useState(1)
 
   const router = useRouter()
   const { id } = router.query
@@ -128,6 +129,7 @@ const SlideEditor = () => {
     const heightScale = editorHeight / targetHeight
 
     const newScale = Math.min(widthScale, heightScale)
+    setScale(newScale)
     slideElement.style.transform = `scale(${newScale})`
   }, [])
 
@@ -262,6 +264,7 @@ const SlideEditor = () => {
                   <DraggableTextBox
                     key={textbox.id}
                     textbox={textbox}
+                    scale={scale}
                   />
                 </div>
               ))}
@@ -273,6 +276,7 @@ const SlideEditor = () => {
                   <DraggableSlideImage
                     key={image.id}
                     image={image}
+                    scale={scale}
                   />
                 </div>
               ))}

--- a/frontend/src/hooks/useDrag.ts
+++ b/frontend/src/hooks/useDrag.ts
@@ -5,22 +5,30 @@ import { useState, useCallback } from 'react'
 export const useDrag = (
   initialPosition: { x: number; y: number },
   contentId: string,
+  size: { width: number; height: number },
 ) => {
   const [isDragging, setIsDragging] = useState(false)
   const [dragStart, setDragStart] = useState<{ x: number; y: number } | null>(
     null,
   )
-  const [position, setPosition] = useState(initialPosition)
   const [isVerticalCenter, setIsVerticalCenter] = useState(false)
   const [isHorizontalCenter, setIsHorizontalCenter] = useState(false)
-  const [, setSlides] = useAtom(slidesState)
+  const [slides, setSlides] = useAtom(slidesState)
 
   const handleDragMouseDown = useCallback(
     (e: React.MouseEvent) => {
-      setDragStart({ x: e.clientX - position.x, y: e.clientY - position.y })
-      setIsDragging(true)
+      const content = slides
+        .flatMap((slide) => [...slide.textboxes, ...slide.images])
+        .find((content) => content.id === contentId)
+      if (content) {
+        setDragStart({
+          x: e.clientX - content.x,
+          y: e.clientY - content.y,
+        })
+        setIsDragging(true)
+      }
     },
-    [position.x, position.y],
+    [slides, contentId],
   )
 
   const handleDragMouseUp = useCallback(() => {
@@ -29,87 +37,103 @@ export const useDrag = (
     setIsVerticalCenter(false)
     setIsDragging(false)
     setDragStart(null)
-    setSlides((prev) =>
-      prev.map((slide) => {
-        const allcontent = [...slide.textboxes, ...slide.images]
-        allcontent.map((content) => {
-          if (content.id === contentId) {
-            content.x = position.x
-            content.y = position.y
-          }
-          return content
-        })
-        return slide
-      }),
-    )
-  }, [contentId, isDragging, position.x, position.y, setSlides])
+  }, [isDragging])
 
   const handleDragMouseMove = useCallback(
     (e: MouseEvent) => {
       if (!isDragging || !dragStart) return
-      //変数設定
-      const SLIDESIZE_HALF = { width: 500, height: 281.5 }
-      const centerPositionOfTextBox = {
-        x: position.x + 125,
-        y: position.y + 80,
-      }
-      const movingDistance = {
-        x: Math.abs(e.clientX - dragStart.x - position.x),
-        y: Math.abs(e.clientY - dragStart.y - position.y),
+
+      // スライドサイズの半分
+      const SLIDESIZE_HALF = {
+        width: 500,
+        height: 281.5,
       }
 
-      //縦の座標を中央に寄せる処理
-      if (
-        centerPositionOfTextBox.y > SLIDESIZE_HALF.height - 2 &&
-        centerPositionOfTextBox.y < SLIDESIZE_HALF.height + 2 &&
-        !isHorizontalCenter
-      ) {
-        setPosition({ x: position.x, y: SLIDESIZE_HALF.height - 80 })
-        setIsHorizontalCenter(true)
-        return
-      }
+      setSlides((prevSlides) =>
+        prevSlides.map((slide) => {
+          const updateContentPosition = (content) => {
+            if (content.id === contentId) {
+              const centerPositionOfTextBox = {
+                x: content.x + size.width / 2,
+                y: content.y + size.height / 2,
+              }
+              const movingDistance = {
+                x: Math.abs(e.clientX - dragStart.x - content.x),
+                y: Math.abs(e.clientY - dragStart.y - content.y),
+              }
 
-      //横の座標を中央に寄せる処理
-      if (
-        centerPositionOfTextBox.x > SLIDESIZE_HALF.width - 2 &&
-        centerPositionOfTextBox.x < SLIDESIZE_HALF.width + 2 &&
-        !isVerticalCenter
-      ) {
-        setPosition({ x: SLIDESIZE_HALF.width - 125, y: position.y })
-        setIsVerticalCenter(true)
-        return
-      }
+              // 縦の座標を中央に寄せる処理
+              if (
+                centerPositionOfTextBox.y > SLIDESIZE_HALF.height - 2 &&
+                centerPositionOfTextBox.y < SLIDESIZE_HALF.height + 2 &&
+                !isHorizontalCenter
+              ) {
+                setIsHorizontalCenter(true)
+                return {
+                  ...content,
+                  y: SLIDESIZE_HALF.height - size.height / 2,
+                }
+              }
 
-      //引っ掛かりをもたせる処理->if-elseif-elseif
-      if (isHorizontalCenter && isVerticalCenter) {
-        if (movingDistance.x < 15 && movingDistance.y < 15) {
-          setPosition({ x: position.x, y: position.y })
-          return
-        }
-        setIsHorizontalCenter(false)
-        setIsVerticalCenter(false)
-      } else if (isHorizontalCenter && !isVerticalCenter) {
-        if (movingDistance.y < 15) {
-          setPosition({ x: e.clientX - dragStart.x, y: position.y })
-          return
-        }
-        setIsHorizontalCenter(false)
-      } else if (!isHorizontalCenter && isVerticalCenter) {
-        if (movingDistance.x < 15) {
-          setPosition({ x: position.x, y: e.clientY - dragStart.y })
-          return
-        }
-        setIsVerticalCenter(false)
-      }
+              // 横の座標を中央に寄せる処理
+              if (
+                centerPositionOfTextBox.x > SLIDESIZE_HALF.width - 2 &&
+                centerPositionOfTextBox.x < SLIDESIZE_HALF.width + 2 &&
+                !isVerticalCenter
+              ) {
+                setIsVerticalCenter(true)
+                return { ...content, x: SLIDESIZE_HALF.width - size.width / 2 }
+              }
 
-      setPosition({ x: e.clientX - dragStart.x, y: e.clientY - dragStart.y })
+              // 引っ掛かりをもたせる処理
+              if (isHorizontalCenter && isVerticalCenter) {
+                if (movingDistance.x < 15 && movingDistance.y < 15) {
+                  return content
+                }
+                setIsHorizontalCenter(false)
+                setIsVerticalCenter(false)
+              } else if (isHorizontalCenter && !isVerticalCenter) {
+                if (movingDistance.y < 15) {
+                  return { ...content, x: e.clientX - dragStart.x }
+                }
+                setIsHorizontalCenter(false)
+              } else if (!isHorizontalCenter && isVerticalCenter) {
+                if (movingDistance.x < 15) {
+                  return { ...content, y: e.clientY - dragStart.y }
+                }
+                setIsVerticalCenter(false)
+              }
+
+              return {
+                ...content,
+                x: e.clientX - dragStart.x,
+                y: e.clientY - dragStart.y,
+              }
+            }
+            return content
+          }
+
+          return {
+            ...slide,
+            textboxes: slide.textboxes.map(updateContentPosition),
+            images: slide.images.map(updateContentPosition),
+          }
+        }),
+      )
     },
-    [isDragging, dragStart, position, isVerticalCenter, isHorizontalCenter],
+    [
+      isDragging,
+      dragStart,
+      size,
+      isHorizontalCenter,
+      isVerticalCenter,
+      contentId,
+      setSlides,
+    ],
   )
 
   return {
     isDragging,
-    position,
     isVerticalCenter,
     isHorizontalCenter,
     handleDragMouseDown,

--- a/frontend/src/hooks/useResize.ts
+++ b/frontend/src/hooks/useResize.ts
@@ -118,15 +118,15 @@ export const useResize = (
               if (newOptions.width < 10 || newOptions.height < 10)
                 return content
 
-              setResizeStart({ x: e.clientX, y: e.clientY })
-
-              return {
+              const updatedContent = {
                 ...content,
                 width: newOptions.width,
                 height: newOptions.height,
                 x: newOptions.x,
                 y: newOptions.y,
               }
+
+              return updatedContent
             }
             return content
           }
@@ -142,6 +142,8 @@ export const useResize = (
           }
         }),
       )
+
+      setResizeStart({ x: e.clientX, y: e.clientY })
     },
     [isResizing, resizeStart, resizeDirection, contentId, setSlides, scale],
   )


### PR DESCRIPTION
## 対応するIssue

- #73

## 概要

1.ドラッグの際の補助線バグの修正。
2.リサイズのバグの修正。
3.ウィンドウサイズ変更時、ドラッグとリサイズの挙動がマウスカーソルから大幅にずれる問題を修正。]

## 実装した内容の詳細

1→なぜか補助線のロジックが書き換えられていた。
2→カスタムフック作成時に、positionという値の変更ををuseResizeからしか受け取っていなかった。
atomでも、stateでもテキストボックスの状態を持っていたので、atomのみに変更。
3→ウィンドウサイズ変更にともなってスライドの大きさをcssのscaleで変更していたためscaleの倍率が１から大きく外れた場合、座標計算が合わなくなっていた。scaleをstateでもって、それに応じた計算をすることで解決。

## スクリーンショット

ファイルサイズ大きすぎてはれませんでした()
ドラッグリサイズの動作確認入念にしてあります。

## その他

変更とても多いです。不明点あれば聞いてください。
