### PR TITLE
fix: 初期値をatomで持つように

### DIFF
--- a/frontend/src/jotai/atoms.ts
+++ b/frontend/src/jotai/atoms.ts
@@ -1,6 +1,8 @@
 import { atom } from 'jotai'
 import type { Slide } from '../types/Slide'
 
-export const slidesState = atom<Slide[]>([])
+export const slidesState = atom<Slide[]>([
+  { title: 'New Slide', slideId: '0', images: [], textboxes: [] },
+])
 
 export const currentSlideIdState = atom<number>(0)

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -1,21 +1,10 @@
 import { useRouter } from 'next/router'
 import styles from '../styles/Home.module.css'
-import { currentSlideIdState, slidesState } from '@/jotai/atoms'
-import { useAtom } from 'jotai'
-import type { Slide } from '@/types/Slide'
 
 const Home = () => {
-  const [slides, setSlides] = useAtom(slidesState)
   const router = useRouter()
 
   const createNewSlide = () => {
-    const newSlide: Slide = {
-      title: 'New Slide',
-      slideId: '0',
-      images: [],
-      textboxes: [],
-    }
-    setSlides([newSlide])
     router.push(`/slide/0`)
   }
 


### PR DESCRIPTION
## 対応するIssue

- #78

## 概要

- atomを持たない際にエラー落ちする問題を修正

## 実装した内容の詳細

- atomを初期値で持つように
  - 遷移時に付与する仕組みを削除

