### PR TITLE
フォントサイズコンポーネントの値が選択中のテキストに連動して変更されない問題を修正

### DIFF
--- a/frontend/src/components/ToolBar.tsx
+++ b/frontend/src/components/ToolBar.tsx
@@ -91,7 +91,7 @@ const ToolBar: React.FC<Props> = ({
         }
         value={
           selectedTextBox
-            ? selectedTextBox.editor?.getAttributes('fontSize').fontSize
+            ? selectedTextBox.editor?.getAttributes('fontSize').size
             : ''
         }
       >

--- a/frontend/src/jotai/atoms.ts
+++ b/frontend/src/jotai/atoms.ts
@@ -1,6 +1,8 @@
 import { atom } from 'jotai'
 import type { Slide } from '../types/Slide'
 
-export const slidesState = atom<Slide[]>([])
+export const slidesState = atom<Slide[]>([
+  { title: 'New Slide', slideId: '0', images: [], textboxes: [] },
+])
 
 export const currentSlideIdState = atom<number>(0)

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -1,21 +1,10 @@
 import { useRouter } from 'next/router'
 import styles from '../styles/Home.module.css'
-import { currentSlideIdState, slidesState } from '@/jotai/atoms'
-import { useAtom } from 'jotai'
-import type { Slide } from '@/types/Slide'
 
 const Home = () => {
-  const [slides, setSlides] = useAtom(slidesState)
   const router = useRouter()
 
   const createNewSlide = () => {
-    const newSlide: Slide = {
-      title: 'New Slide',
-      slideId: '0',
-      images: [],
-      textboxes: [],
-    }
-    setSlides([newSlide])
     router.push(`/slide/0`)
   }
 


### PR DESCRIPTION
## 対応するIssue

- #85 

## 概要

- フォントサイズ選択コンポーネントの値がフォーカスしたテキストボックスに応じて変更されない問題を修正しました

## 実装した内容の詳細

- tiptapのeditorからgetAttributesするときのパラメータの指定ミスを修正

## スクリーンショット

修正後

https://github.com/AllenShintani/Skalp_AI/assets/36080294/ded94f5a-b19e-4f27-b65c-ed7128ad55d8


