### PR TITLE
テキストの色を変更する機能を追加

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@prisma/client": "^5.11.0",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bullet-list": "^2.4.0",
+    "@tiptap/extension-color": "^2.4.0",
     "@tiptap/extension-font-family": "^2.4.0",
     "@tiptap/extension-list-item": "^2.4.0",
     "@tiptap/extension-placeholder": "^2.4.0",

--- a/frontend/src/components/SlideEditor.tsx
+++ b/frontend/src/components/SlideEditor.tsx
@@ -25,7 +25,8 @@ const SlideEditor = () => {
   const [slides, setSlides] = useAtom(slidesState)
   const [currentSlide, setCurrentSlide] = useAtom(currentSlideIdState)
   const [scale, setScale] = useState(1)
-  const [selectedRange, setSelectedRange] = useState<{
+  ///Tiptapのメソッドではテキスト選択が解除されるため
+  const [selectedTextRange, setSelectedRange] = useState<{
     from: number
     to: number
   } | null>(null)
@@ -222,16 +223,16 @@ const SlideEditor = () => {
       const selectedTextBox = slides[currentSlide].textboxes.find(
         (textbox) => textbox.isSelected,
       )
-      if (selectedTextBox && selectedTextBox.editor && selectedRange) {
+      if (selectedTextBox && selectedTextBox.editor && selectedTextRange) {
         selectedTextBox.editor
           .chain()
           .focus()
-          .setTextSelection(selectedRange)
+          .setTextSelection(selectedTextRange)
           .setColor(color)
           .run()
       }
     },
-    [currentSlide, slides, selectedRange],
+    [currentSlide, slides, selectedTextRange],
   )
 
   const saveSelection = useCallback(() => {

--- a/frontend/src/hooks/useClickOutside.ts
+++ b/frontend/src/hooks/useClickOutside.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react'
+
+type Handler = (event: MouseEvent) => void
+
+export function useClickOutside<T extends HTMLElement = HTMLElement>(
+  handler: Handler,
+): React.RefObject<T> {
+  const ref = useRef<T>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        handler(event)
+      }
+    }
+
+    document.addEventListener('click', handleClickOutside)
+    return () => {
+      document.removeEventListener('click', handleClickOutside)
+    }
+  }, [handler])
+
+  return ref
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "@prisma/client": "^5.11.0",
         "@tiptap/core": "^2.4.0",
         "@tiptap/extension-bullet-list": "^2.4.0",
+        "@tiptap/extension-color": "^2.4.0",
         "@tiptap/extension-font-family": "^2.4.0",
         "@tiptap/extension-list-item": "^2.4.0",
         "@tiptap/extension-placeholder": "^2.4.0",
@@ -3414,6 +3415,20 @@
       "peerDependencies": {
         "@tiptap/core": "^2.0.0",
         "@tiptap/pm": "^2.0.0"
+      }
+    },
+    "node_modules/@tiptap/extension-color": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-2.4.0.tgz",
+      "integrity": "sha512-aVuqGtzTIZO93niADdu+Hx8g03X0pS7wjrJcCcYkkDEbC/siC03zlxKZIYBW1Jiabe99Z7/s2KdtLoK6DW2A2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0",
+        "@tiptap/extension-text-style": "^2.0.0"
       }
     },
     "node_modules/@tiptap/extension-document": {


### PR DESCRIPTION
## 対応するIssue

- #93 

## 概要

- テキストの色を変更する機能を追加しました。

## 実装した内容の詳細

- フォントのマークボタンを押したらカラーピッカーが出現します。カラーを選択して入力するとその色になります。また、カラーピッカーを開いたときに選択していた部分の色が変化するようになっています。クリックアウトサイド（カラーピッカー以外の部分をクリックするとカラーピッカーが閉じる）機能があるのでcloseボタンを押す必要がないのですが一応残しています。

## 動作デモ

https://github.com/AllenShintani/Skalp_AI/assets/107395154/8d719b2e-7ff7-4c26-93b9-5a22e3c5f8b9



- 

## その他

- 現在背景色、字の色それぞれ別でカラーピッカーのコードを書いているのでもっとコンパクトなコードにできるはずです
