### PR TITLE
背景色をスライドプレビューに追加

### DIFF
--- a/frontend/src/components/SlidePreview.tsx
+++ b/frontend/src/components/SlidePreview.tsx
@@ -3,7 +3,6 @@ import styles from './SlidePreview.module.css'
 import type { Slide, SlideImage, TextBox } from '@/types/Slide'
 import DOMPurify from 'dompurify'
 import parse from 'html-react-parser'
-import { useRef } from 'react'
 
 type SlideImagePreviewProps = {
   image: SlideImage
@@ -52,9 +51,17 @@ const TextBoxPreview: React.FC<TextBoxPreviewProps> = ({ textbox }) => {
   return <div style={style}>{parse(sanitizedTextBoxHTML)}</div>
 }
 
+const slideBackgroundColor = (slide: Slide) => {
+  console.log(slide.backgroundColor)
+  return slide.backgroundColor
+}
+
 const SlidePreview: React.FC<{ slide: Slide }> = ({ slide }) => {
   return (
-    <div className={styles.slidePreview}>
+    <div
+      style={{ backgroundColor: slideBackgroundColor(slide) }}
+      className={styles.slidePreview}
+    >
       {slide.textboxes.map((textbox) => (
         <TextBoxPreview
           key={textbox.id}

--- a/frontend/src/components/SlidePreview.tsx
+++ b/frontend/src/components/SlidePreview.tsx
@@ -52,7 +52,6 @@ const TextBoxPreview: React.FC<TextBoxPreviewProps> = ({ textbox }) => {
 }
 
 const slideBackgroundColor = (slide: Slide) => {
-  console.log(slide.backgroundColor)
   return slide.backgroundColor
 }
 


### PR DESCRIPTION
## 対応するIssue

- #99 

## 概要

- 背景色がスライドプレビューに適応されるようにした

## スクリーンショット
![2AF87B61-6874-4F32-BB47-8F3C29E65F46](https://github.com/AllenShintani/Skalp_AI/assets/107373499/58a74abd-16c4-47a0-bf8e-38b8e97a8ae5)

## その他

- 今後テーマの適応時、図形の追加時にも編集が必要

